### PR TITLE
Task AS-2196 - Estourar um erro no COMClient quando não passar um link para a função shortify

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -43,6 +43,7 @@ declare module '@aftersale/comclient-sdk/lib/application/service/internal-client
   };
   export type TemplateCreated = {
       id: string;
+      providerId: string;
   };
   export type TemplateUpdated = {
       id: string;
@@ -253,8 +254,8 @@ declare module '@aftersale/comclient-sdk/lib/infra/senders/sender-factory' {
   import { MessageServiceBusSender } from '@aftersale/comclient-sdk/lib/infra/senders/service-bus/message';
   import { SenderOptions } from '@aftersale/comclient-sdk/lib/infra/senders/types/sender-options';
   export default class SenderFactory {
-      static senders: (typeof MessageServiceBusSender | typeof FakerMessageSender)[];
-      static create(provider: string, connectionString: string, options?: SenderOptions): MessageServiceBusSender | FakerMessageSender;
+      static senders: (typeof FakerMessageSender | typeof MessageServiceBusSender)[];
+      static create(provider: string, connectionString: string, options?: SenderOptions): FakerMessageSender | MessageServiceBusSender;
   }
 
 }

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -157,6 +157,7 @@ declare module '@aftersale/comclient-sdk/lib/domain/entities/message/sms' {
       private get variables();
       private replaceVariables;
       private normalize;
+      private verify;
   }
   export {};
 
@@ -186,6 +187,12 @@ declare module '@aftersale/comclient-sdk/lib/domain/entities/message/whatsapp' {
       };
   }
   export {};
+
+}
+declare module '@aftersale/comclient-sdk/lib/domain/errors/link-not-provided' {
+  export class LinkNotProvidedError extends Error {
+      constructor();
+  }
 
 }
 declare module '@aftersale/comclient-sdk/lib/domain/protocols/message-dispatcher' {

--- a/dist/index.esm.js
+++ b/dist/index.esm.js
@@ -155,6 +155,13 @@ var SMSShortify = class {
   }
 };
 
+// lib/domain/errors/link-not-provided.ts
+var LinkNotProvidedError = class extends Error {
+  constructor() {
+    super("Error: Found link but variable not provided");
+  }
+};
+
 // lib/domain/entities/message/sms.ts
 var SMS = class {
   constructor({ message, recipient, externalId, scheduledTo }) {
@@ -170,6 +177,7 @@ var SMS = class {
       suffix: this.suffix,
       link: this.variables?.link
     });
+    this.verify();
   }
   getMessage() {
     this.format();
@@ -228,6 +236,10 @@ var SMS = class {
       prefix: message.prefix ? normalizeDiacritics(message.prefix) : void 0,
       variables: message.variables
     };
+  }
+  verify() {
+    if (this.message.text.includes("$link") && !this.message.variables?.link)
+      throw new LinkNotProvidedError();
   }
 };
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -194,6 +194,13 @@ var SMSShortify = class {
   }
 };
 
+// lib/domain/errors/link-not-provided.ts
+var LinkNotProvidedError = class extends Error {
+  constructor() {
+    super("Error: Found link but variable not provided");
+  }
+};
+
 // lib/domain/entities/message/sms.ts
 var SMS = class {
   constructor({ message, recipient, externalId, scheduledTo }) {
@@ -209,6 +216,7 @@ var SMS = class {
       suffix: this.suffix,
       link: this.variables?.link
     });
+    this.verify();
   }
   getMessage() {
     this.format();
@@ -267,6 +275,10 @@ var SMS = class {
       prefix: message.prefix ? (0, import_normalize_text.normalizeDiacritics)(message.prefix) : void 0,
       variables: message.variables
     };
+  }
+  verify() {
+    if (this.message.text.includes("$link") && !this.message.variables?.link)
+      throw new LinkNotProvidedError();
   }
 };
 

--- a/lib/application/service/internal-client.ts
+++ b/lib/application/service/internal-client.ts
@@ -18,7 +18,8 @@ export type MessageData = {
 type Success = Omit<MessageData, 'sentAt'> & {sentAt: Date}
 
 export type TemplateCreated = {
-  id: string
+  id: string,
+  providerId: string
 }
 
 export type TemplateUpdated = {

--- a/lib/domain/entities/message/sms.ts
+++ b/lib/domain/entities/message/sms.ts
@@ -1,6 +1,7 @@
 import { Message, MessageData } from './message'
 import { normalizeDiacritics } from 'normalize-text'
 import { SMSShortify } from '../../service/smsshortify'
+import { LinkNotProvidedError } from '../../errors/link-not-provided';
 
 type MessageType = {
   prefix?: string;
@@ -38,6 +39,7 @@ export class SMS implements Message {
       suffix: this.suffix,
       link: this.variables?.link
     })
+    this.verify()
   }
 
   public getMessage() {
@@ -109,5 +111,9 @@ export class SMS implements Message {
       prefix: message.prefix ? normalizeDiacritics(message.prefix) : undefined,
       variables: message.variables
     }
+  }
+
+  private verify() {
+    if (this.message.text.includes('$link') && !this.message.variables?.link) throw new LinkNotProvidedError()
   }
 }

--- a/lib/domain/entities/message/sms.ts
+++ b/lib/domain/entities/message/sms.ts
@@ -1,7 +1,7 @@
 import { Message, MessageData } from './message'
 import { normalizeDiacritics } from 'normalize-text'
 import { SMSShortify } from '../../service/smsshortify'
-import { LinkNotProvidedError } from '../../errors/link-not-provided';
+import { LinkNotProvidedError } from '../../errors/link-not-provided'
 
 type MessageType = {
   prefix?: string;

--- a/lib/domain/errors/link-not-provided.ts
+++ b/lib/domain/errors/link-not-provided.ts
@@ -1,5 +1,5 @@
 export class LinkNotProvidedError extends Error {
   constructor() {
-    super('Error: Found link but variable not provided');
+    super('Error: Found link but variable not provided')
   }
 }

--- a/lib/domain/errors/link-not-provided.ts
+++ b/lib/domain/errors/link-not-provided.ts
@@ -1,0 +1,5 @@
+export class LinkNotProvidedError extends Error {
+  constructor() {
+    super('Error: Found link but variable not provided');
+  }
+}

--- a/test/domain/service/internal-client.spec.ts
+++ b/test/domain/service/internal-client.spec.ts
@@ -88,7 +88,8 @@ tap.test('should send a template created', async (t) => {
   })
 
   const message = {
-    id: '2323232'
+    id: '2323232',
+    providerId: '123'
   }
 
   await client.templateCreated(message)

--- a/test/entities/message/sms.spec.ts
+++ b/test/entities/message/sms.spec.ts
@@ -270,5 +270,18 @@ tap.test('SMS shortify', (t) => {
     t.equal(message.text.length <= 240, true)
     t.end()
   })
+
+  t.test('should get error when link is not provided but found in message text', (t) => {
+    t.throws(() => new SMS(
+      {
+        message: {
+          text: mockMessage.long
+        },
+        recipient
+      }
+    ))
+    t.end()
+  })
+
   t.end()
 })


### PR DESCRIPTION
- [x] Adicionada verficiação para quando passar `$link` e não tiver um link para substituir nas variáveis estourar um error.
- [x] Teste