### PR TITLE
feat: add receive message event to internal client

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,4 +69,40 @@ O email recebe um objeto de configurações com as seguintes propriedades:
 |-------|------|-------------|----------|
 |recipient| `{email: string}` | Para quem o email será enviado | `true` |
 |message| `{body: string, from: string, subject: string}` | Corpo do email que será enviado | `true` |
-| externalId | `string` | Id de referência para identificar uma mensagem no COM-service | `false` | 
+| externalId | `string` | Id de referência para identificar uma mensagem no COM-service | `false` |
+| scheduleTo | `Date` | data para envio da mensagem | `false` |
+| replyingTo | `string` | Id de uma mensagem que está sendo respondida | `false` |
+
+### SMS
+
+SMS recebe um objeto de configurações com as seguintes propriedades:
+
+| field | type | description | required |
+|-------|------|-------------|----------|
+|recipient| `{phone: string}` | Para quem a SMS será enviada | `true` |
+|message| `{prefix?: string, suffix?: string, text: string, variables?: {[string]: string}}` | Corpo da SMS que será enviada | `true` |
+| externalId | `string` | Id de referência para identificar uma mensagem no COM-service | `false` |
+| scheduleTo | `Date` | data para envio da mensagem | `false` |
+| replyingTo | `string` | Id de uma mensagem que está sendo respondida | `false` |
+
+as SMSs podem ser encurtadas chamando o método `shortify` antes do seu envio
+
+```ts
+const sms = new SMS({...})
+sms.shortify()
+client.dispatch(sms)
+```
+
+É importante notar que ao chamar o método shortify, é necessário ter uma variável `link` na mensagem
+
+### Whatsapp
+
+O whatsapp recebe um objeto de configurações com as seguintes propriedades:
+
+| field | type | description | required |
+|-------|------|-------------|----------|
+|recipient| `{phone: string}` | Para quem a mensagem será enviada | `true` |
+|message| `{ type: 'text'; text: string } \| { type: 'template'; template: string; fields: Record<string, string> }` | Corpo da mensagem que será enviada | `true` |
+| externalId | `string` | Id de referência para identificar uma mensagem no COM-service | `false` |
+| scheduleTo | `Date` | data para envio da mensagem | `false` |
+| replyingTo | `string` | Id de uma mensagem que está sendo respondida | `false` |

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -288,8 +288,8 @@ declare module '@aftersale/comclient-sdk/lib/infra/senders/sender-factory' {
   import { MessageServiceBusSender } from '@aftersale/comclient-sdk/lib/infra/senders/service-bus/message';
   import { SenderOptions } from '@aftersale/comclient-sdk/lib/infra/senders/types/sender-options';
   export default class SenderFactory {
-      static senders: (typeof MessageServiceBusSender | typeof FakerMessageSender)[];
-      static create(provider: string, connectionString: string, options?: SenderOptions): MessageServiceBusSender | FakerMessageSender;
+      static senders: (typeof FakerMessageSender | typeof MessageServiceBusSender)[];
+      static create(provider: string, connectionString: string, options?: SenderOptions): FakerMessageSender | MessageServiceBusSender;
   }
 
 }

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -50,6 +50,15 @@ declare module '@aftersale/comclient-sdk/lib/application/service/internal-client
       id: string;
       status: 'approved' | 'submitted' | 'negated';
   };
+  export type MessageReceived = {
+      from: string;
+      id: string;
+      text: {
+          body: string;
+      };
+      timestamp: string;
+      clientId: string;
+  };
   export class COMInternal {
       private senderOptions?;
       private readonly provider;
@@ -57,12 +66,14 @@ declare module '@aftersale/comclient-sdk/lib/application/service/internal-client
       private readonly SUCCESS_QUEUE;
       private readonly TEMPLATE_CREATED_QUEUE;
       private readonly TEMPLATE_UPDATED_QUEUE;
+      private readonly MESSAGE_RECEIVED;
       private readonly connectionString;
       constructor({ environment, provider, connectionString, options }: Params);
       error(data: MessageData): Promise<void>;
       success(data: Success): Promise<void>;
       templateCreated(data: TemplateCreated): Promise<void>;
       templateUpdated(data: TemplateUpdated): Promise<void>;
+      messageReceived(data: MessageReceived): Promise<void>;
   }
   export {};
 

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -95,13 +95,15 @@ declare module '@aftersale/comclient-sdk/lib/domain/entities/message/email' {
       readonly message: MessageType;
       readonly recipient: RecipientType;
       readonly scheduledTo?: string;
-      constructor({ message, recipient, externalId, scheduledTo }: Pick<EmailData, 'message' | 'recipient' | 'externalId' | 'scheduledTo'>);
+      readonly replyingTo?: string;
+      constructor({ message, recipient, externalId, scheduledTo, replyingTo }: Pick<EmailData, 'message' | 'recipient' | 'externalId' | 'scheduledTo' | 'replyingTo'>);
       getMessage(): {
           channel: string;
           externalId: string | undefined;
           recipient: RecipientType;
           message: MessageType;
           scheduledTo: string | undefined;
+          replyingTo: string | undefined;
       };
   }
   export {};
@@ -112,9 +114,11 @@ declare module '@aftersale/comclient-sdk/lib/domain/entities/message/message' {
       externalId?: string;
       channel: string;
       scheduledTo?: Date;
+      replyingTo?: string;
   };
   export interface Message {
       externalId?: string;
+      replyingTo?: string;
       channel?: string;
       scheduledTo?: string;
       getMessage(): Partial<Omit<MessageData, 'scheduledTo'>> & {
@@ -145,7 +149,8 @@ declare module '@aftersale/comclient-sdk/lib/domain/entities/message/sms' {
       private readonly recipient;
       private readonly message;
       private readonly shortifyService;
-      constructor({ message, recipient, externalId, scheduledTo }: Pick<SMSData, 'message' | 'recipient' | 'externalId' | 'scheduledTo'>);
+      readonly replyingTo?: string;
+      constructor({ message, recipient, externalId, scheduledTo, replyingTo }: Pick<SMSData, 'message' | 'recipient' | 'externalId' | 'scheduledTo' | 'replyingTo'>);
       getMessage(): {
           externalId: string | undefined;
           message: {
@@ -154,6 +159,7 @@ declare module '@aftersale/comclient-sdk/lib/domain/entities/message/sms' {
           channel: string;
           recipient: RecipientType;
           scheduledTo: string | undefined;
+          replyingTo: string | undefined;
       };
       shortify(char?: number): void;
       private format;
@@ -196,13 +202,15 @@ declare module '@aftersale/comclient-sdk/lib/domain/entities/message/whatsapp' {
       readonly message: MessageType;
       readonly scheduledTo?: string;
       readonly recipient: RecipientType;
-      constructor({ message, recipient, externalId, scheduledTo }: Pick<WhatsappData, 'message' | 'recipient' | 'externalId' | 'scheduledTo'>);
+      readonly replyingTo?: string;
+      constructor({ message, recipient, externalId, scheduledTo, replyingTo }: Pick<WhatsappData, 'message' | 'recipient' | 'externalId' | 'scheduledTo' | 'replyingTo'>);
       getMessage(): {
           channel: string;
           externalId: string | undefined;
           recipient: RecipientType;
           message: MessageType;
           scheduledTo: string | undefined;
+          replyingTo: string | undefined;
       };
   }
   export {};

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -52,12 +52,9 @@ declare module '@aftersale/comclient-sdk/lib/application/service/internal-client
   };
   export type MessageReceived = {
       from: string;
-      id: string;
-      text: {
-          body: string;
-      };
+      text: string;
       timestamp: string;
-      clientId: string;
+      clientId?: string;
   };
   export class COMInternal {
       private senderOptions?;

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -288,8 +288,8 @@ declare module '@aftersale/comclient-sdk/lib/infra/senders/sender-factory' {
   import { MessageServiceBusSender } from '@aftersale/comclient-sdk/lib/infra/senders/service-bus/message';
   import { SenderOptions } from '@aftersale/comclient-sdk/lib/infra/senders/types/sender-options';
   export default class SenderFactory {
-      static senders: (typeof FakerMessageSender | typeof MessageServiceBusSender)[];
-      static create(provider: string, connectionString: string, options?: SenderOptions): FakerMessageSender | MessageServiceBusSender;
+      static senders: (typeof MessageServiceBusSender | typeof FakerMessageSender)[];
+      static create(provider: string, connectionString: string, options?: SenderOptions): MessageServiceBusSender | FakerMessageSender;
   }
 
 }

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -55,6 +55,7 @@ declare module '@aftersale/comclient-sdk/lib/application/service/internal-client
       text: string;
       timestamp: string;
       clientId?: string;
+      profileName: string;
   };
   export class COMInternal {
       private senderOptions?;
@@ -288,8 +289,8 @@ declare module '@aftersale/comclient-sdk/lib/infra/senders/sender-factory' {
   import { MessageServiceBusSender } from '@aftersale/comclient-sdk/lib/infra/senders/service-bus/message';
   import { SenderOptions } from '@aftersale/comclient-sdk/lib/infra/senders/types/sender-options';
   export default class SenderFactory {
-      static senders: (typeof MessageServiceBusSender | typeof FakerMessageSender)[];
-      static create(provider: string, connectionString: string, options?: SenderOptions): MessageServiceBusSender | FakerMessageSender;
+      static senders: (typeof FakerMessageSender | typeof MessageServiceBusSender)[];
+      static create(provider: string, connectionString: string, options?: SenderOptions): FakerMessageSender | MessageServiceBusSender;
   }
 
 }

--- a/dist/index.esm.js
+++ b/dist/index.esm.js
@@ -278,6 +278,7 @@ var COMInternal = class {
     this.SUCCESS_QUEUE = `${environment}--message-success`;
     this.TEMPLATE_CREATED_QUEUE = `${environment}--template-created`;
     this.TEMPLATE_UPDATED_QUEUE = `${environment}--template-status`;
+    this.MESSAGE_RECEIVED = `${environment}--receive-message`;
   }
   async error(data) {
     const sender = SenderFactory.create(this.provider, this.connectionString, this.senderOptions);
@@ -294,6 +295,10 @@ var COMInternal = class {
   async templateUpdated(data) {
     const sender = SenderFactory.create(this.provider, this.connectionString, this.senderOptions);
     return await sender.dispatch({ ...data }, this.TEMPLATE_UPDATED_QUEUE);
+  }
+  async messageReceived(data) {
+    const sender = SenderFactory.create(this.provider, this.connectionString, this.senderOptions);
+    return await sender.dispatch({ ...data }, this.MESSAGE_RECEIVED);
   }
 };
 export {

--- a/dist/index.esm.js
+++ b/dist/index.esm.js
@@ -102,12 +102,13 @@ var COMClient = class {
 
 // lib/domain/entities/message/email.ts
 var Email = class {
-  constructor({ message, recipient, externalId, scheduledTo }) {
+  constructor({ message, recipient, externalId, scheduledTo, replyingTo }) {
     this.channel = "email";
     this.externalId = externalId;
     this.message = message;
     this.recipient = recipient;
     this.scheduledTo = scheduledTo?.toISOString();
+    this.replyingTo = replyingTo;
   }
   getMessage() {
     return {
@@ -115,13 +116,21 @@ var Email = class {
       externalId: this.externalId,
       recipient: this.recipient,
       message: this.message,
-      scheduledTo: this.scheduledTo
+      scheduledTo: this.scheduledTo,
+      replyingTo: this.replyingTo
     };
   }
 };
 
 // lib/domain/entities/message/sms.ts
 import { normalizeDiacritics } from "normalize-text";
+
+// lib/domain/errors/link-not-provided.ts
+var LinkNotProvidedError = class extends Error {
+  constructor() {
+    super("Error: Found link but variable not provided");
+  }
+};
 
 // lib/domain/service/smsshortify.ts
 var SMSShortify = class {
@@ -155,21 +164,15 @@ var SMSShortify = class {
   }
 };
 
-// lib/domain/errors/link-not-provided.ts
-var LinkNotProvidedError = class extends Error {
-  constructor() {
-    super("Error: Found link but variable not provided");
-  }
-};
-
 // lib/domain/entities/message/sms.ts
 var SMS = class {
-  constructor({ message, recipient, externalId, scheduledTo }) {
+  constructor({ message, recipient, externalId, scheduledTo, replyingTo }) {
     this.channel = "sms";
     this.externalId = externalId;
     this.message = this.normalize(message);
     this.recipient = recipient;
     this.scheduledTo = scheduledTo?.toISOString();
+    this.replyingTo = replyingTo;
     this.replaceVariables();
     this.shortifyService = new SMSShortify({
       text: this.text,
@@ -188,7 +191,8 @@ var SMS = class {
       },
       channel: this.channel,
       recipient: this.recipient,
-      scheduledTo: this.scheduledTo
+      scheduledTo: this.scheduledTo,
+      replyingTo: this.replyingTo
     };
   }
   shortify(char = 160) {
@@ -249,13 +253,15 @@ var Whatsapp = class {
     message,
     recipient,
     externalId,
-    scheduledTo
+    scheduledTo,
+    replyingTo
   }) {
     this.channel = "whatsapp";
     this.externalId = externalId;
     this.message = message;
     this.recipient = recipient;
     this.scheduledTo = scheduledTo?.toISOString();
+    this.replyingTo = replyingTo;
   }
   getMessage() {
     return {
@@ -263,7 +269,8 @@ var Whatsapp = class {
       externalId: this.externalId,
       recipient: this.recipient,
       message: this.message,
-      scheduledTo: this.scheduledTo
+      scheduledTo: this.scheduledTo,
+      replyingTo: this.replyingTo
     };
   }
 };

--- a/dist/index.js
+++ b/dist/index.js
@@ -317,6 +317,7 @@ var COMInternal = class {
     this.SUCCESS_QUEUE = `${environment}--message-success`;
     this.TEMPLATE_CREATED_QUEUE = `${environment}--template-created`;
     this.TEMPLATE_UPDATED_QUEUE = `${environment}--template-status`;
+    this.MESSAGE_RECEIVED = `${environment}--receive-message`;
   }
   async error(data) {
     const sender = SenderFactory.create(this.provider, this.connectionString, this.senderOptions);
@@ -333,6 +334,10 @@ var COMInternal = class {
   async templateUpdated(data) {
     const sender = SenderFactory.create(this.provider, this.connectionString, this.senderOptions);
     return await sender.dispatch({ ...data }, this.TEMPLATE_UPDATED_QUEUE);
+  }
+  async messageReceived(data) {
+    const sender = SenderFactory.create(this.provider, this.connectionString, this.senderOptions);
+    return await sender.dispatch({ ...data }, this.MESSAGE_RECEIVED);
   }
 };
 module.exports = __toCommonJS(lib_exports);

--- a/dist/index.js
+++ b/dist/index.js
@@ -141,12 +141,13 @@ var COMClient = class {
 
 // lib/domain/entities/message/email.ts
 var Email = class {
-  constructor({ message, recipient, externalId, scheduledTo }) {
+  constructor({ message, recipient, externalId, scheduledTo, replyingTo }) {
     this.channel = "email";
     this.externalId = externalId;
     this.message = message;
     this.recipient = recipient;
     this.scheduledTo = scheduledTo?.toISOString();
+    this.replyingTo = replyingTo;
   }
   getMessage() {
     return {
@@ -154,13 +155,21 @@ var Email = class {
       externalId: this.externalId,
       recipient: this.recipient,
       message: this.message,
-      scheduledTo: this.scheduledTo
+      scheduledTo: this.scheduledTo,
+      replyingTo: this.replyingTo
     };
   }
 };
 
 // lib/domain/entities/message/sms.ts
 var import_normalize_text = require("normalize-text");
+
+// lib/domain/errors/link-not-provided.ts
+var LinkNotProvidedError = class extends Error {
+  constructor() {
+    super("Error: Found link but variable not provided");
+  }
+};
 
 // lib/domain/service/smsshortify.ts
 var SMSShortify = class {
@@ -194,21 +203,15 @@ var SMSShortify = class {
   }
 };
 
-// lib/domain/errors/link-not-provided.ts
-var LinkNotProvidedError = class extends Error {
-  constructor() {
-    super("Error: Found link but variable not provided");
-  }
-};
-
 // lib/domain/entities/message/sms.ts
 var SMS = class {
-  constructor({ message, recipient, externalId, scheduledTo }) {
+  constructor({ message, recipient, externalId, scheduledTo, replyingTo }) {
     this.channel = "sms";
     this.externalId = externalId;
     this.message = this.normalize(message);
     this.recipient = recipient;
     this.scheduledTo = scheduledTo?.toISOString();
+    this.replyingTo = replyingTo;
     this.replaceVariables();
     this.shortifyService = new SMSShortify({
       text: this.text,
@@ -227,7 +230,8 @@ var SMS = class {
       },
       channel: this.channel,
       recipient: this.recipient,
-      scheduledTo: this.scheduledTo
+      scheduledTo: this.scheduledTo,
+      replyingTo: this.replyingTo
     };
   }
   shortify(char = 160) {
@@ -288,13 +292,15 @@ var Whatsapp = class {
     message,
     recipient,
     externalId,
-    scheduledTo
+    scheduledTo,
+    replyingTo
   }) {
     this.channel = "whatsapp";
     this.externalId = externalId;
     this.message = message;
     this.recipient = recipient;
     this.scheduledTo = scheduledTo?.toISOString();
+    this.replyingTo = replyingTo;
   }
   getMessage() {
     return {
@@ -302,7 +308,8 @@ var Whatsapp = class {
       externalId: this.externalId,
       recipient: this.recipient,
       message: this.message,
-      scheduledTo: this.scheduledTo
+      scheduledTo: this.scheduledTo,
+      replyingTo: this.replyingTo
     };
   }
 };

--- a/lib/application/service/client.ts
+++ b/lib/application/service/client.ts
@@ -10,7 +10,7 @@ type ClientParams = {
   connectionString: string;
   origin: string;
   clientId: string;
-  options?: SenderOptions;
+  options?: SenderOptions
 };
 
 export class COMClient {

--- a/lib/application/service/client.ts
+++ b/lib/application/service/client.ts
@@ -10,7 +10,7 @@ type ClientParams = {
   connectionString: string;
   origin: string;
   clientId: string;
-  options?: SenderOptions
+  options?: SenderOptions;
 };
 
 export class COMClient {

--- a/lib/application/service/internal-client.ts
+++ b/lib/application/service/internal-client.ts
@@ -28,6 +28,16 @@ export type TemplateUpdated = {
   status: 'approved' | 'submitted' | 'negated';
 };
 
+export type MessageReceived = {
+  from: string,
+  id: string,
+  text: {
+    body: string
+  },
+  timestamp: string,
+  clientId: string
+}
+
 export class COMInternal {
   private senderOptions?: SenderOptions
   private readonly provider: string
@@ -35,6 +45,7 @@ export class COMInternal {
   private readonly SUCCESS_QUEUE: string
   private readonly TEMPLATE_CREATED_QUEUE: string
   private readonly TEMPLATE_UPDATED_QUEUE: string
+  private readonly MESSAGE_RECEIVED: string
 
   private readonly connectionString: string
 
@@ -46,6 +57,7 @@ export class COMInternal {
     this.SUCCESS_QUEUE = `${environment}--message-success`
     this.TEMPLATE_CREATED_QUEUE = `${environment}--template-created`
     this.TEMPLATE_UPDATED_QUEUE = `${environment}--template-status`
+    this.MESSAGE_RECEIVED = `${environment}--receive-message`
   }
 
   public async error(data: MessageData) {
@@ -70,5 +82,11 @@ export class COMInternal {
     const sender = SenderFactory.create(this.provider, this.connectionString, this.senderOptions)
 
     return await sender.dispatch({ ...data }, this.TEMPLATE_UPDATED_QUEUE)
+  }
+
+  public async messageReceived(data: MessageReceived) {
+    const sender = SenderFactory.create(this.provider, this.connectionString, this.senderOptions)
+
+    return await sender.dispatch({ ...data }, this.MESSAGE_RECEIVED)
   }
 }

--- a/lib/application/service/internal-client.ts
+++ b/lib/application/service/internal-client.ts
@@ -30,12 +30,9 @@ export type TemplateUpdated = {
 
 export type MessageReceived = {
   from: string,
-  id: string,
-  text: {
-    body: string
-  },
+  text: string,
   timestamp: string,
-  clientId: string
+  clientId?: string
 }
 
 export class COMInternal {

--- a/lib/application/service/internal-client.ts
+++ b/lib/application/service/internal-client.ts
@@ -32,7 +32,8 @@ export type MessageReceived = {
   from: string,
   text: string,
   timestamp: string,
-  clientId?: string
+  clientId?: string,
+  profileName: string
 }
 
 export class COMInternal {

--- a/lib/domain/entities/message/email.ts
+++ b/lib/domain/entities/message/email.ts
@@ -21,12 +21,14 @@ export class Email implements Message {
   readonly message: MessageType
   readonly recipient: RecipientType
   readonly scheduledTo?: string
+  readonly replyingTo?: string
 
-  constructor({ message, recipient, externalId, scheduledTo }: Pick<EmailData, 'message' | 'recipient' | 'externalId' | 'scheduledTo'>) {
+  constructor({ message, recipient, externalId, scheduledTo, replyingTo }: Pick<EmailData, 'message' | 'recipient' | 'externalId' | 'scheduledTo' | 'replyingTo'>) {
     this.externalId = externalId
     this.message = message
     this.recipient = recipient
     this.scheduledTo = scheduledTo?.toISOString()
+    this.replyingTo = replyingTo
   }
 
   getMessage() {
@@ -35,7 +37,8 @@ export class Email implements Message {
       externalId: this.externalId,
       recipient: this.recipient,
       message: this.message,
-      scheduledTo: this.scheduledTo
+      scheduledTo: this.scheduledTo,
+      replyingTo: this.replyingTo
     }
   }
 }

--- a/lib/domain/entities/message/message.ts
+++ b/lib/domain/entities/message/message.ts
@@ -2,11 +2,14 @@ export type MessageData = {
   externalId?: string;
   channel: string;
   scheduledTo?: Date
+  replyingTo?: string
 }
 
 export interface Message {
    externalId?: string
+   replyingTo?: string
    channel?: string
    scheduledTo?: string
+
    getMessage(): Partial<Omit<MessageData, 'scheduledTo'>> & {scheduledTo?: string}
 }

--- a/lib/domain/entities/message/sms.ts
+++ b/lib/domain/entities/message/sms.ts
@@ -1,7 +1,7 @@
-import { Message, MessageData } from './message'
 import { normalizeDiacritics } from 'normalize-text'
-import { SMSShortify } from '../../service/smsshortify'
 import { LinkNotProvidedError } from '../../errors/link-not-provided'
+import { SMSShortify } from '../../service/smsshortify'
+import { Message, MessageData } from './message'
 
 type MessageType = {
   prefix?: string;
@@ -26,12 +26,14 @@ export class SMS implements Message {
   private readonly recipient: RecipientType
   private readonly message: MessageType
   private readonly shortifyService: SMSShortify
+  readonly replyingTo?: string
 
-  constructor({ message, recipient, externalId, scheduledTo }: Pick<SMSData, 'message' | 'recipient' | 'externalId' | 'scheduledTo'>) {
+  constructor({ message, recipient, externalId, scheduledTo, replyingTo }: Pick<SMSData, 'message' | 'recipient' | 'externalId' | 'scheduledTo' | 'replyingTo'>) {
     this.externalId = externalId
     this.message = this.normalize(message)
     this.recipient = recipient
     this.scheduledTo = scheduledTo?.toISOString()
+    this.replyingTo = replyingTo
     this.replaceVariables()
     this.shortifyService = new SMSShortify({
       text: this.text,
@@ -52,7 +54,8 @@ export class SMS implements Message {
       },
       channel: this.channel,
       recipient: this.recipient,
-      scheduledTo: this.scheduledTo
+      scheduledTo: this.scheduledTo,
+      replyingTo: this.replyingTo
     }
   }
 

--- a/lib/domain/entities/message/whatsapp.ts
+++ b/lib/domain/entities/message/whatsapp.ts
@@ -21,17 +21,20 @@ export class Whatsapp implements Message {
   readonly message: MessageType
   readonly scheduledTo?: string
   readonly recipient: RecipientType
+  readonly replyingTo?: string
 
   constructor({
     message,
     recipient,
     externalId,
-    scheduledTo
-  }: Pick<WhatsappData, 'message' | 'recipient' | 'externalId' | 'scheduledTo'>) {
+    scheduledTo,
+    replyingTo
+  }: Pick<WhatsappData, 'message' | 'recipient' | 'externalId' | 'scheduledTo' | 'replyingTo'>) {
     this.externalId = externalId
     this.message = message
     this.recipient = recipient
     this.scheduledTo = scheduledTo?.toISOString()
+    this.replyingTo = replyingTo
   }
 
   getMessage() {
@@ -40,7 +43,8 @@ export class Whatsapp implements Message {
       externalId: this.externalId,
       recipient: this.recipient,
       message: this.message,
-      scheduledTo: this.scheduledTo
+      scheduledTo: this.scheduledTo,
+      replyingTo: this.replyingTo
     }
   }
 }

--- a/test/domain/service/client.spec.ts
+++ b/test/domain/service/client.spec.ts
@@ -4,7 +4,7 @@ import { SMS } from '../../../lib/domain/entities/message/sms'
 import { ProviderNotImplemented } from '../../../lib/errors/provider-not-implemented'
 import { FakerMessageSender } from '../../../lib/infra/senders/faker/message'
 import emailTest from '../../fixtures/email'
-import { whatsappTextTest, whatsappTemplateTest } from '../../fixtures/whatsapp'
+import { whatsappTemplateTest, whatsappTextTest } from '../../fixtures/whatsapp'
 
 type SMSData = Partial<Omit<MessageData, 'scheduledTo'>> & { scheduledTo?: string; message: { text: string } };
 
@@ -126,6 +126,23 @@ tap.test('should send a whatsapp text message using fake provider', async (t) =>
   })
 
   const message = new Whatsapp(whatsappTextTest as WhatsappData)
+
+  await client.dispatch(message)
+  t.equal(FakerMessageSender.messages.length, 1)
+  t.match(FakerMessageSender.messages[0], message.getMessage())
+  t.end()
+})
+
+tap.test('should send whatsapp message replying to other', async (t) => {
+  t.before(() => FakerMessageSender.cleanMessages())
+  const client = new COMClient({
+    provider: 'faker',
+    connectionString: 'faker_secret',
+    clientId: '4632b0b0-9be2-4797-92ad-7c53ff3c5662',
+    origin: 'pc da nasa'
+  })
+
+  const message = new Whatsapp({ ...whatsappTextTest, replyingTo: '1234' } as WhatsappData)
 
   await client.dispatch(message)
   t.equal(FakerMessageSender.messages.length, 1)

--- a/test/domain/service/internal-client.spec.ts
+++ b/test/domain/service/internal-client.spec.ts
@@ -154,9 +154,7 @@ tap.test('should send a received message event', async (t) => {
     id: '2323232',
     clientId: '123',
     from: '999999999',
-    text: {
-      body: 'hello test'
-    },
+    text: 'hello test',
     timestamp: '2020-10-10T09:00:00'
   }
 

--- a/test/domain/service/internal-client.spec.ts
+++ b/test/domain/service/internal-client.spec.ts
@@ -151,7 +151,6 @@ tap.test('should send a received message event', async (t) => {
     connectionString: 'faker_secret'
   })
   const message = {
-    id: '2323232',
     clientId: '123',
     from: '999999999',
     text: 'hello test',

--- a/test/domain/service/internal-client.spec.ts
+++ b/test/domain/service/internal-client.spec.ts
@@ -2,6 +2,7 @@ import tap from 'tap'
 import {
   COMInternal,
   MessageData,
+  MessageReceived,
   TemplateCreated,
   TemplateUpdated
 } from '../../../lib/application/service/internal-client'
@@ -139,6 +140,30 @@ tap.test('should send a template updated with submitted status', async (t) => {
   t.equal(FakerMessageSender.messages.length, 1)
   t.equal((FakerMessageSender.messages[0] as TemplateUpdated).id, '2323232')
   t.equal((FakerMessageSender.messages[0] as TemplateUpdated).status, 'submitted')
+
+  t.end()
+})
+
+tap.test('should send a received message event', async (t) => {
+  t.before(() => FakerMessageSender.cleanMessages())
+  const client = new COMInternal({
+    provider: 'faker',
+    connectionString: 'faker_secret'
+  })
+  const message = {
+    id: '2323232',
+    clientId: '123',
+    from: '999999999',
+    text: {
+      body: 'hello test'
+    },
+    timestamp: '2020-10-10T09:00:00'
+  }
+
+  await client.messageReceived(message)
+
+  t.equal(FakerMessageSender.messages.length, 1)
+  t.same((FakerMessageSender.messages[0] as MessageReceived), message)
 
   t.end()
 })

--- a/test/domain/service/internal-client.spec.ts
+++ b/test/domain/service/internal-client.spec.ts
@@ -154,7 +154,8 @@ tap.test('should send a received message event', async (t) => {
     clientId: '123',
     from: '999999999',
     text: 'hello test',
-    timestamp: '2020-10-10T09:00:00'
+    timestamp: '2020-10-10T09:00:00',
+    profileName: 'John Doo'
   }
 
   await client.messageReceived(message)

--- a/test/entities/message/email.spec.ts
+++ b/test/entities/message/email.spec.ts
@@ -14,3 +14,11 @@ tap.test('should have need props', (t) => {
 
   t.end()
 })
+
+tap.test('should have replying to props', (t) => {
+  const message = new Email({ ...emailTest, replyingTo: '1234' })
+
+  t.equal(message.replyingTo, '1234')
+
+  t.end()
+})

--- a/test/entities/message/sms.spec.ts
+++ b/test/entities/message/sms.spec.ts
@@ -25,6 +25,14 @@ tap.test('should have need props', (t) => {
   t.end()
 })
 
+tap.test('should have replying to props', (t) => {
+  const message = new SMS({ message: { text: 'test' }, recipient, replyingTo: '1234' })
+
+  t.equal(message.replyingTo, '1234')
+
+  t.end()
+})
+
 tap.test('should normalize diacritics in message', (t) => {
   const msg = new SMS({
     message: {

--- a/test/entities/message/whatsapp.spec.ts
+++ b/test/entities/message/whatsapp.spec.ts
@@ -14,3 +14,11 @@ tap.test('should have need props', (t) => {
 
   t.end()
 })
+
+tap.test('should have replying to props', (t) => {
+  const message = new Whatsapp({ ...whatsappTextTest as WhatsappData, replyingTo: '1234' })
+
+  t.equal(message.replyingTo, '1234')
+
+  t.end()
+})


### PR DESCRIPTION
# O que foi feito

### COM-internal
- adicionado fila para notificar mensagens recebidas (usada pelo zap-service)

### COM-client
- Adicionado `replying to` ao corpo das mensagens