### PR TITLE
feat: add cc to email message

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -273,8 +273,8 @@ declare module '@aftersale/comclient-sdk/lib/infra/senders/sender-factory' {
   import { MessageServiceBusSender } from '@aftersale/comclient-sdk/lib/infra/senders/service-bus/message';
   import { SenderOptions } from '@aftersale/comclient-sdk/lib/infra/senders/types/sender-options';
   export default class SenderFactory {
-      static senders: (typeof MessageServiceBusSender | typeof FakerMessageSender)[];
-      static create(provider: string, connectionString: string, options?: SenderOptions): MessageServiceBusSender | FakerMessageSender;
+      static senders: (typeof FakerMessageSender | typeof MessageServiceBusSender)[];
+      static create(provider: string, connectionString: string, options?: SenderOptions): FakerMessageSender | MessageServiceBusSender;
   }
 
 }

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -73,6 +73,7 @@ declare module '@aftersale/comclient-sdk/lib/domain/entities/message/email' {
       from: string;
       subject: string;
       body: string;
+      cc?: string[];
   };
   type RecipientType = {
       email: string;

--- a/lib/domain/entities/message/email.ts
+++ b/lib/domain/entities/message/email.ts
@@ -3,7 +3,8 @@ import { Message, MessageData } from './message'
 type MessageType = {
   from: string,
   subject: string,
-  body: string
+  body: string,
+  cc: string
 };
 
 type RecipientType = {

--- a/lib/domain/entities/message/email.ts
+++ b/lib/domain/entities/message/email.ts
@@ -4,7 +4,7 @@ type MessageType = {
   from: string,
   subject: string,
   body: string,
-  cc: string
+  cc?: string[]
 };
 
 type RecipientType = {

--- a/test/domain/service/client.spec.ts
+++ b/test/domain/service/client.spec.ts
@@ -4,7 +4,7 @@ import { SMS } from '../../../lib/domain/entities/message/sms'
 import { ProviderNotImplemented } from '../../../lib/errors/provider-not-implemented'
 import { FakerMessageSender } from '../../../lib/infra/senders/faker/message'
 import emailTest from '../../fixtures/email'
-import { whatsappTextTest, whatsappTemplateTest } from '../../fixtures/whatsapp'
+import { whatsappTemplateTest, whatsappTextTest } from '../../fixtures/whatsapp'
 
 type SMSData = Partial<Omit<MessageData, 'scheduledTo'>> & { scheduledTo?: string; message: { text: string } };
 
@@ -45,6 +45,28 @@ tap.test('should send a email message using fake provider', async (t) => {
   await client.dispatch(message)
   t.equal(FakerMessageSender.messages.length, 1)
   t.match(FakerMessageSender.messages[0], message.getMessage())
+  t.end()
+})
+
+tap.test('should send a email message using fake provider with cc', async (t) => {
+  t.before(() => FakerMessageSender.cleanMessages())
+  const client = new COMClient({
+    provider: 'faker',
+    connectionString: 'faker_secret',
+    clientId: '4632b0b0-9be2-4797-92ad-7c53ff3c5662',
+    origin: 'pc da nasa'
+  })
+
+  const message = new Email({ ...emailTest, message: { ...emailTest.message, cc: ['test@test.com'] } })
+
+  await client.dispatch(message)
+  t.equal(FakerMessageSender.messages.length, 1)
+  t.match(FakerMessageSender.messages[0], message.getMessage())
+  t.equal((FakerMessageSender.messages[0] as {
+    message: {
+      cc: string[]
+    }
+  }).message.cc[0], message.message.cc?.[0])
   t.end()
 })
 


### PR DESCRIPTION
# Adicionar "em copia" para mensagem de email

Adicionado a opção `cc` ao criar um novo email